### PR TITLE
Expose GridDisk and GridDiskDistances, implement GridDisk for a CellSet

### DIFF
--- a/pkg/h3/cell_set.go
+++ b/pkg/h3/cell_set.go
@@ -36,6 +36,10 @@ func (cs CellSet) Cells() []Cell {
 	return cells
 }
 
+func (cs CellSet) String() string {
+	return fmt.Sprintf("%v", cs.Cells())
+}
+
 // Strings returns the cells in the set as a list of hex-encoded strings.
 func (cs CellSet) Strings() []string {
 	ss := make([]string, 0, len(cs))
@@ -54,4 +58,39 @@ func (cs CellSet) Contains(c Cell) bool {
 // Add adds a cell to the set.
 func (cs CellSet) Add(c Cell) {
 	cs[c] = struct{}{}
+}
+
+// Union returns the union of two cell sets.
+func (cs CellSet) Union(other CellSet) CellSet {
+	newSet := make(CellSet, len(cs)+len(other))
+	for c := range cs {
+		newSet[c] = struct{}{}
+	}
+	for c := range other {
+		newSet[c] = struct{}{}
+	}
+	return newSet
+}
+
+// GridDisk returns the cells in the set's grid disk of radius k. The grid disk
+// is the set of cells within k grid steps of the cells in the set. k=0 returns
+// the set itself.
+func (cs CellSet) GridDisk(k int) (CellSet, error) {
+	if k == 0 {
+		return cs, nil
+	}
+
+	newSet := make(CellSet)
+	for cell := range cs {
+		gridDiskListForCell, err := cell.gridDisk(k)
+		if err != nil {
+			return nil, fmt.Errorf("error computing grid disk for cell %s: %w", cell, err)
+		}
+
+		gridDiskSetForCell := NewCellSetFromCells(gridDiskListForCell)
+
+		newSet = newSet.Union(gridDiskSetForCell)
+	}
+
+	return newSet, nil
 }

--- a/pkg/h3/cell_set.go
+++ b/pkg/h3/cell_set.go
@@ -82,7 +82,7 @@ func (cs CellSet) GridDisk(k int) (CellSet, error) {
 
 	newSet := make(CellSet)
 	for cell := range cs {
-		gridDiskListForCell, err := cell.gridDisk(k)
+		gridDiskListForCell, err := cell.GridDisk(k)
 		if err != nil {
 			return nil, fmt.Errorf("error computing grid disk for cell %s: %w", cell, err)
 		}

--- a/pkg/h3/grid_disk.go
+++ b/pkg/h3/grid_disk.go
@@ -10,7 +10,7 @@ const (
 	K_ALL_CELLS_AT_RES_15 = 13780510
 )
 
-// Maximum number of cells that result from the gridDisk algorithm with the
+// Maximum number of cells that result from the GridDisk algorithm with the
 // given k. Formula source and proof: https://oeis.org/A003215
 func maxGridDiskSize(k int) (int, error) {
 	if k < 0 {
@@ -22,7 +22,7 @@ func maxGridDiskSize(k int) (int, error) {
 		// more cells than exist in the H3 grid at the finest resolution. This is a
 		// problem since the function does signed integer arithmetic on `k`, which could
 		// overflow. To prevent that, instead substitute the maximum number of cells in
-		// the grid, as it should not be possible for the gridDisk functions to exceed
+		// the grid, as it should not be possible for the GridDisk functions to exceed
 		// that. Note this is not resolution specific. So, when resolution < 15, this
 		// function may still estimate a size larger than the number of cells in the
 		// grid.
@@ -32,7 +32,7 @@ func maxGridDiskSize(k int) (int, error) {
 	return 3*k*(k+1) + 1, nil
 }
 
-// gridDiskDistancesSafe is the safe but slow version of gridDiskDistances (also
+// gridDiskDistancesSafe is the safe but slow version of GridDiskDistances (also
 // called by it when needed).
 //
 // Includes the origin cell in the output list (treating it as a hash set) and
@@ -139,21 +139,21 @@ func (c Cell) gridDiskUnsafe(k int) ([]Cell, error) {
 	return cells, err
 }
 
-// gridDisk produces cells within k distance of the origin cell.
+// GridDisk produces cells within k distance of the origin cell.
 //
 // k-ring 0 is defined as the origin cell, k-ring 1 is defined as k-ring 0 and
 // all neighboring cells, and so on.
-func (c Cell) gridDisk(k int) ([]Cell, error) {
-	cells, _, err := c.gridDiskDistances(k)
+func (c Cell) GridDisk(k int) ([]Cell, error) {
+	cells, _, err := c.GridDiskDistances(k)
 	return cells, err
 }
 
-// gridDiskDistances produces cells and their distances from the given origin
+// GridDiskDistances produces cells and their distances from the given origin
 // cell, up to distance k.
 //
 // k-ring 0 is defined as the origin cell, k-ring 1 is defined as k-ring 0 and
 // all neighboring cells, and so on.
-func (c Cell) gridDiskDistances(k int) ([]Cell, []int, error) {
+func (c Cell) GridDiskDistances(k int) ([]Cell, []int, error) {
 	// Try the faster, unsafe version first
 	cells, distances, err := c.gridDiskDistancesUnsafe(k)
 	if err == nil {

--- a/pkg/h3/grid_disk_test.go
+++ b/pkg/h3/grid_disk_test.go
@@ -79,8 +79,8 @@ func TestCell_gridDisk(t *testing.T) {
 	})
 
 	t.Run("invalid cell", func(t *testing.T) {
-		_, err := Cell(0x7fffffffffffffff).gridDisk(1000)
-		assert.Error(t, err, "should not be able to create a cell from an invalid index")
+		_, err := Cell(0x7fffffffffffffff).GridDisk(1000)
+		assert.Error(t, err, "should not be able to create a grid disk from an invalid index")
 	})
 
 	t.Run("san francisco k=0", func(t *testing.T) {
@@ -89,7 +89,7 @@ func TestCell_gridDisk(t *testing.T) {
 		sf, err := NewCellFromLatLng(sfLL, 0)
 		assert.NoError(t, err)
 
-		cells, distances, err := sf.gridDiskDistances(0)
+		cells, distances, err := sf.GridDiskDistances(0)
 		assert.NoError(t, err)
 		assert.Len(t, cells, 1)
 		assert.Len(t, distances, 1)
@@ -106,7 +106,7 @@ func TestCell_gridDisk(t *testing.T) {
 		sf, err := NewCellFromLatLng(sfLL, 1)
 		assert.NoError(t, err)
 
-		cells, distances, err := sf.gridDiskDistances(1)
+		cells, distances, err := sf.GridDiskDistances(1)
 		assert.NoError(t, err)
 		assert.Len(t, cells, 7)
 		assert.Len(t, distances, 7)
@@ -132,7 +132,7 @@ func TestCell_gridDisk(t *testing.T) {
 		sf, err := NewCellFromLatLng(sfLL, 0)
 		assert.NoError(t, err)
 
-		cells, distances, err := sf.gridDiskDistances(1)
+		cells, distances, err := sf.GridDiskDistances(1)
 		assert.NoError(t, err)
 		assert.Len(t, cells, 7)
 		assert.Len(t, distances, 7)


### PR DESCRIPTION
This adds `CellSet.GridDisk()` and exposes `Cell.GridDisk()` and `Cell.GridDiskDistances()` to support it.