### PR TITLE
Add CellSet Parent function and test

### DIFF
--- a/pkg/h3/cell_set.go
+++ b/pkg/h3/cell_set.go
@@ -327,3 +327,41 @@ func (cs CellSet) Subtract(other CellSet) (CellSet, error) {
 
 	return result, nil
 }
+
+// Parent returns a new cell set that contains the parent cells of the cells in
+// the given set. The resolution of the new set is the given resolution. It is an
+// error to call this function with a resolution greater than the set's
+// resolution, if the set is empty, or if the resolution is not consistent within
+// the set.
+func (cs CellSet) Parent(resolution int) (CellSet, error) {
+	// If the set is empty, return an error
+	if len(cs) == 0 {
+		return nil, fmt.Errorf("empty cell set")
+	}
+
+	setResolution, err := cs.Resolution()
+	if err != nil {
+		return nil, fmt.Errorf("cell set is not consistent resolution: %w", err)
+	}
+
+	// If the resolution is the same as the set's resolution, return the set itself
+	if resolution == setResolution {
+		return cs, nil
+	}
+
+	// Can't get children using the parent function
+	if resolution > setResolution {
+		return nil, fmt.Errorf("resolution %d is greater than current resolution %d", resolution, setResolution)
+	}
+
+	result := make(CellSet, len(cs))
+	for c := range cs {
+		parent, err := c.Parent(resolution)
+		if err != nil {
+			return nil, fmt.Errorf("error getting parent for cell %s: %w", c, err)
+		}
+		result.Add(parent)
+	}
+
+	return result, nil
+}

--- a/pkg/h3/cell_set_test.go
+++ b/pkg/h3/cell_set_test.go
@@ -595,3 +595,68 @@ func TestCellSet_Subtract(t *testing.T) {
 		})
 	}
 }
+
+func TestCellSet_Parent(t *testing.T) {
+	type args struct {
+		resolution int
+	}
+	tests := []struct {
+		name    string
+		cs      CellSet
+		args    args
+		want    CellSet
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			"empty",
+			CellSet{},
+			args{0},
+			nil,
+			assert.Error,
+		},
+		{
+			"single cell, same resolution",
+			CellSet{0x87283082affffff: {}},
+			args{7},
+			CellSet{0x87283082affffff: {}},
+			assert.NoError,
+		},
+		{
+			"single cell, different resolution",
+			CellSet{0x87283082affffff: {}},
+			args{5},
+			CellSet{0x85283083fffffff: {}},
+			assert.NoError,
+		},
+		{
+			"single cell, greater resolution",
+			CellSet{0x87283082affffff: {}},
+			args{8},
+			nil,
+			assert.Error,
+		},
+		{
+			"single cell, invalid resolution",
+			CellSet{0x87283082affffff: {}},
+			args{-1},
+			nil,
+			assert.Error,
+		},
+		{
+			"multiple cells, different resolution",
+			CellSet{0x872830876ffffff: {}, 0x87283082bffffff: {}, 0x87283082affffff: {}},
+			args{5},
+			CellSet{0x85283083fffffff: {}, 0x85283087fffffff: {}},
+			assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.cs.Parent(tt.args.resolution)
+			if !tt.wantErr(t, err, fmt.Sprintf("Parent(%v)", tt.args.resolution)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "Parent(%v)", tt.args.resolution)
+		})
+	}
+}


### PR DESCRIPTION
Adds a `Parent()` function to `CellSet`.